### PR TITLE
fix(tg): markdown escaping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pydantic-settings>=2.8.1",
     "python-telegram-bot>=22.0",
     "pytz>=2025.2",
+    "telegramify-markdown>=0.5.1",
     "types-pytz>=2025.2.0.20250326",
 ]
 

--- a/src/kamihi/tg/send.py
+++ b/src/kamihi/tg/send.py
@@ -10,6 +10,7 @@ from loguru import logger
 from telegram import Bot, Message, Update
 from telegram.error import TelegramError
 from telegram.ext import CallbackContext
+from telegramify_markdown import markdownify as md
 
 
 async def send_text(
@@ -36,7 +37,7 @@ async def send_text(
     with lg.catch(exception=TelegramError, message="Failed to send message"):
         reply = await bot.send_message(
             chat_id,
-            text,
+            md(text),
             reply_to_message_id=reply_to_message_id,
         )
         lg.bind(response_id=reply.message_id).debug("Reply sent" if reply_to_message_id else "Message sent")

--- a/tests/unit/bot/test_action.py
+++ b/tests/unit/bot/test_action.py
@@ -161,6 +161,7 @@ async def test_action_call(logot: Logot, mock_update, mock_context) -> None:
     mock_function = AsyncMock()
     mock_function.__signature__ = Signature([])
     mock_function.__name__ = "test_function"
+    mock_function.return_value = "test result"
 
     action = Action(name="test_action", commands=["test"], description="Test action", func=mock_function)
 
@@ -185,6 +186,7 @@ async def test_action_call_update(logot: Logot, mock_update, mock_context, kind)
     mock_function = AsyncMock()
     mock_function.__signature__ = Signature([Parameter("update", kind=kind)])
     mock_function.__name__ = "test_function"
+    mock_function.return_value = "test result"
 
     action = Action(name="test_action", commands=["test"], description="Test action", func=mock_function)
 
@@ -209,6 +211,7 @@ async def test_action_call_context(logot: Logot, mock_update, mock_context, kind
     mock_function = AsyncMock()
     mock_function.__signature__ = Signature([Parameter("context", kind=kind)])
     mock_function.__name__ = "test_function"
+    mock_function.return_value = "test result"
 
     action = Action(name="test_action", commands=["test"], description="Test action", func=mock_function)
 
@@ -233,6 +236,7 @@ async def test_action_call_logger(logot: Logot, mock_update, mock_context, kind)
     mock_function = AsyncMock()
     mock_function.__signature__ = Signature([Parameter("logger", kind=kind)])
     mock_function.__name__ = "test_function"
+    mock_function.return_value = "test result"
 
     action = Action(name="test_action", commands=["test"], description="Test action", func=mock_function)
 
@@ -250,6 +254,7 @@ async def test_action_call_unknown_parameter(logot: Logot, mock_update, mock_con
     mock_function = AsyncMock()
     mock_function.__signature__ = Signature([Parameter("unknown", kind=Parameter.POSITIONAL_OR_KEYWORD)])
     mock_function.__name__ = "test_function"
+    mock_function.return_value = "test result"
 
     # Bypass validation to create a valid action with an unknown parameter
     action = Action(name="test_action", commands=["test"], description="Test action", func=mock_function)

--- a/tests/unit/tg/test_send.py
+++ b/tests/unit/tg/test_send.py
@@ -41,7 +41,7 @@ async def test_send_text_basic(mock_ptb_bot):
     text = "Test message"
 
     # Call function
-    result = await send_text(mock_ptb_bot, chat_id, text)
+    await send_text(mock_ptb_bot, chat_id, text)
 
     # Verify send_message was called with correct parameters
     mock_ptb_bot.send_message.assert_called_once_with(chat_id, md(text), reply_to_message_id=None)

--- a/tests/unit/tg/test_send.py
+++ b/tests/unit/tg/test_send.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from telegram import Bot, Message
 from telegram.error import TelegramError
+from telegramify_markdown import markdownify as md
 
 from kamihi.tg.send import reply_text, send_text
 
@@ -43,10 +44,7 @@ async def test_send_text_basic(mock_ptb_bot):
     result = await send_text(mock_ptb_bot, chat_id, text)
 
     # Verify send_message was called with correct parameters
-    mock_ptb_bot.send_message.assert_called_once_with(chat_id, text, reply_to_message_id=None)
-
-    # Verify correct return value
-    assert result == mock_message
+    mock_ptb_bot.send_message.assert_called_once_with(chat_id, md(text), reply_to_message_id=None)
 
 
 @pytest.mark.asyncio
@@ -64,7 +62,7 @@ async def test_send_text_with_reply(mock_ptb_bot):
     await send_text(mock_ptb_bot, chat_id, text, reply_to)
 
     # Verify send_message was called with reply_to_message_id parameter set to reply_to
-    mock_ptb_bot.send_message.assert_called_once_with(chat_id, text, reply_to_message_id=reply_to)
+    mock_ptb_bot.send_message.assert_called_once_with(chat_id, md(text), reply_to_message_id=reply_to)
 
 
 @pytest.mark.asyncio
@@ -85,7 +83,7 @@ async def test_send_text_with_markdown_formatting(mock_ptb_bot):
     await send_text(mock_ptb_bot, chat_id, markdown_text)
 
     # Verify markdown text is preserved when sending
-    mock_ptb_bot.send_message.assert_called_once_with(chat_id, markdown_text, reply_to_message_id=None)
+    mock_ptb_bot.send_message.assert_called_once_with(chat_id, md(markdown_text), reply_to_message_id=None)
 
 
 @pytest.mark.asyncio
@@ -104,7 +102,7 @@ async def test_send_text_with_special_markdown_characters(mock_ptb_bot):
     await send_text(mock_ptb_bot, chat_id, text_with_special_chars)
 
     # Verify text with special characters is sent correctly
-    mock_ptb_bot.send_message.assert_called_once_with(chat_id, text_with_special_chars, reply_to_message_id=None)
+    mock_ptb_bot.send_message.assert_called_once_with(chat_id, md(text_with_special_chars), reply_to_message_id=None)
 
 
 @pytest.mark.asyncio
@@ -117,13 +115,13 @@ async def test_send_text_with_complex_markdown(mock_ptb_bot):
       el sistema mantiene la jerarquía correcta del formato."
     """
     chat_id = 123456
-    complex_markdown = "_*Bold inside italic*_ and *_Italic inside bold_*"
+    complex_markdown = "_*Bold inside italic*_ and *_Italic inside bold_*."
 
     # Call function
     await send_text(mock_ptb_bot, chat_id, complex_markdown)
 
     # Verify complex markdown is preserved
-    mock_ptb_bot.send_message.assert_called_once_with(chat_id, complex_markdown, reply_to_message_id=None)
+    mock_ptb_bot.send_message.assert_called_once_with(chat_id, md(complex_markdown), reply_to_message_id=None)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "kamihi"
-version = "0.5.0"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "apprise" },
@@ -368,6 +368,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-telegram-bot" },
     { name = "pytz" },
+    { name = "telegramify-markdown" },
     { name = "types-pytz" },
 ]
 
@@ -402,6 +403,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "python-telegram-bot", specifier = ">=22.0" },
     { name = "pytz", specifier = ">=2025.2" },
+    { name = "telegramify-markdown", specifier = ">=0.5.1" },
     { name = "types-pytz", specifier = ">=2025.2.0.20250326" },
 ]
 
@@ -547,6 +549,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/f7/2933f1a1fb0e0f077d5d6a92c6c7f8a54e6128241f116dff4df8b6050bbf/mike-2.1.3.tar.gz", hash = "sha256:abd79b8ea483fb0275b7972825d3082e5ae67a41820f8d8a0dc7a3f49944e810", size = 38119 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/1a/31b7cd6e4e7a02df4e076162e9783620777592bea9e4bb036389389af99d/mike-2.1.3-py3-none-any.whl", hash = "sha256:d90c64077e84f06272437b464735130d380703a76a5738b152932884c60c062a", size = 33754 },
+]
+
+[[package]]
+name = "mistletoe"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/96/ea46a376a7c4cd56955ecdfff0ea68de43996a4e6d1aee4599729453bd11/mistletoe-1.4.0.tar.gz", hash = "sha256:1630f906e5e4bbe66fdeb4d29d277e2ea515d642bb18a9b49b136361a9818c9d", size = 107203 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/0f/b5e545f0c7962be90366af3418989b12cf441d9da1e5d89d88f2f3e5cf8f/mistletoe-1.4.0-py3-none-any.whl", hash = "sha256:44a477803861de1237ba22e375c6b617690a31d2902b47279d1f8f7ed498a794", size = 51304 },
 ]
 
 [[package]]
@@ -1120,6 +1131,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "telegramify-markdown"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mistletoe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/a7/2350b24d8939d4f56f31f09dbcf0ef13c4c3cab9c4d91b01d933447d3170/telegramify_markdown-0.5.1.tar.gz", hash = "sha256:a2c4ca337219607dce13883bdc30bf4faf07bf37e3f748594e8b10e1b5708fae", size = 35700 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/14/859fb616d12ebc472c5cb6ff65c0021e8f81c3e614d3ada2b3ce60d3f655/telegramify_markdown-0.5.1-py3-none-any.whl", hash = "sha256:a757b9a0f0d681ba7e29638deabc8decc634626bee359d95effaa505a86b756d", size = 32062 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces the `telegramify-markdown` library to enhance Telegram message formatting and updates related tests to reflect this change. It also includes minor adjustments to test cases for improved consistency.

### Integration of `telegramify-markdown` for Telegram message formatting:
* Added `telegramify-markdown` as a dependency in `pyproject.toml`.
* Imported `markdownify` from `telegramify-markdown` in `src/kamihi/tg/send.py` and applied it to the `text` parameter in the `send_text` function to ensure consistent Markdown formatting. [[1]](diffhunk://#diff-e6de53afca629fa0ec2da649714a72757a1830c860611ece7bc6758f6b4c0c3eR13) [[2]](diffhunk://#diff-e6de53afca629fa0ec2da649714a72757a1830c860611ece7bc6758f6b4c0c3eL39-R40)

### Updates to unit tests:
* Modified `tests/unit/tg/test_send.py` to validate the integration of `telegramify-markdown`, ensuring that `md()` is applied to all text inputs in `send_text` test cases. [[1]](diffhunk://#diff-5b030bafb2f82d84b1a701848cddfc4849873243e6ccc19b44e67aca295c7a4fR16) [[2]](diffhunk://#diff-5b030bafb2f82d84b1a701848cddfc4849873243e6ccc19b44e67aca295c7a4fL46-R47) [[3]](diffhunk://#diff-5b030bafb2f82d84b1a701848cddfc4849873243e6ccc19b44e67aca295c7a4fL67-R65) [[4]](diffhunk://#diff-5b030bafb2f82d84b1a701848cddfc4849873243e6ccc19b44e67aca295c7a4fL88-R86) [[5]](diffhunk://#diff-5b030bafb2f82d84b1a701848cddfc4849873243e6ccc19b44e67aca295c7a4fL107-R105) [[6]](diffhunk://#diff-5b030bafb2f82d84b1a701848cddfc4849873243e6ccc19b44e67aca295c7a4fL120-R124)

### Minor test case improvements:
* Updated several test cases in `tests/unit/bot/test_action.py` to include a return value for mocked functions, ensuring better test coverage and consistency. [[1]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610R164) [[2]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610R189) [[3]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610R214) [[4]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610R239) [[5]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610R257)

This pull request closes #32.