### PR TITLE
fix(tg): auth handler now calls check update of wrapped handler

### DIFF
--- a/src/kamihi/tg/handlers/auth_handler.py
+++ b/src/kamihi/tg/handlers/auth_handler.py
@@ -52,4 +52,4 @@ class AuthHandler(BaseHandler):
                 )
                 return False
 
-        return True
+        return self.handler.check_update(update)

--- a/tests/functional/bot/test_action_decorator.py
+++ b/tests/functional/bot/test_action_decorator.py
@@ -41,3 +41,42 @@ class TestActionDecoratorNoParentheses:
         response = await chat.get_response()
 
         assert response.text == "test"
+
+
+class TestActionMultipleDefined:
+    """Test the action decorator with multiple defined actions."""
+
+    @pytest.fixture
+    def user_code(self):
+        """Fixture to provide the user code for the bot."""
+        return {
+            "main.py": dedent("""\
+                              from kamihi import bot
+                             
+                              @bot.action
+                              async def start():
+                                  return "Hello! I'm your friendly bot. How can I help you today?"
+                             
+                              @bot.action
+                              async def start2():
+                                  return "Hello! I'm not your friendly bot."
+                             
+                              bot.start()
+                              """).encode()
+        }
+
+    @pytest.mark.asyncio
+    async def test_action_multiple_defined(self, kamihi, user_in_db, add_permission_for_user, chat: Conversation):
+        """Test the action decorator with multiple defined actions."""
+        add_permission_for_user(user_in_db, "start")
+        add_permission_for_user(user_in_db, "start2")
+
+        await chat.send_message("/start")
+        response = await chat.get_response()
+
+        assert response.text == "Hello! I'm your friendly bot. How can I help you today?"
+
+        await chat.send_message("/start2")
+        response = await chat.get_response()
+
+        assert response.text == "Hello! I'm not your friendly bot."


### PR DESCRIPTION
AuthHandler was only checking if the user was authorized to use the command, not whether it was the correct command. This meant that all commands would execute the first defined action the user was authorized to do.

Closes #43.