### PR TITLE
feat(bot): user can now be requested in action function parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ version_files = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src --cov-report=xml --cov-report=term-missing -n auto --tracing retain-on-failure"
+addopts = "--cov=src --cov-report=xml --cov-report=term-missing --tracing retain-on-failure"
 testpaths = ["tests/"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"

--- a/src/kamihi/bot/action.py
+++ b/src/kamihi/bot/action.py
@@ -19,6 +19,7 @@ from telegram.ext import ApplicationHandlerStop, CallbackContext, CommandHandler
 
 from kamihi.tg import reply_text
 from kamihi.tg.handlers import AuthHandler
+from kamihi.users import get_user_from_telegram_id
 
 from .models import RegisteredAction
 from .utils import COMMAND_REGEX
@@ -111,7 +112,7 @@ class Action:
         # Check if the function has valid parameters
         parameters = inspect.signature(self._func).parameters
         for name, param in parameters.items():
-            if name not in ("update", "context", "logger"):
+            if name not in ("update", "context", "logger", "user"):
                 self._logger.warning(
                     "Invalid parameter '{name}' in function",
                     name=name,
@@ -165,6 +166,8 @@ class Action:
                     value = context
                 case "logger":
                     value = self._logger
+                case "user":
+                    value = get_user_from_telegram_id(update.effective_user.id)
                 case _:
                     value = None
 

--- a/tests/functional/bot/test_action_parameters.py
+++ b/tests/functional/bot/test_action_parameters.py
@@ -1,0 +1,94 @@
+"""
+Functional tests for action parameter injections.
+
+License:
+    MIT
+
+"""
+
+from textwrap import dedent
+
+import pytest
+from mongoengine import StringField
+from pytest_docker_tools.wrappers import Container
+from telethon.tl.custom import Conversation
+
+
+class TestActionParametersUser:
+    """Test action decorator on function with user parameter."""
+
+    @pytest.fixture
+    def user_code(self):
+        """Fixture to provide the user code for the bot."""
+        return {
+            "main.py": dedent("""\
+                              from kamihi import bot, BaseUser
+                             
+                              @bot.action
+                              async def start(user: BaseUser):
+                                  return f"Hello, user with ID {user.telegram_id}!"
+                             
+                              bot.start()
+                              """).encode()
+        }
+
+    @pytest.mark.asyncio
+    async def test_action_parameter_user(self, kamihi, user_in_db, add_permission_for_user, chat: Conversation):
+        """Test the action decorator without parentheses."""
+        add_permission_for_user(user_in_db, "start")
+
+        await chat.send_message("/start")
+        response = await chat.get_response()
+
+        assert response.text == f"Hello, user with ID {user_in_db.telegram_id}!"
+
+
+class TestActionParametersUserCustom:
+    """Test action decorator on function with user parameter and custom user class."""
+
+    @pytest.fixture
+    def user_code(self):
+        """Fixture to provide the user code for the bot."""
+        return {
+            "main.py": dedent("""\
+                              from kamihi import bot, BaseUser
+                              from mongoengine import StringField
+                             
+                              @bot.user_class
+                              class User(BaseUser):
+                                  name: str = StringField()
+                             
+                              @bot.action
+                              async def start(user: User):
+                                  return f"Hello, {user.name}!"
+                             
+                              bot.start()
+                              """).encode()
+        }
+
+    @pytest.fixture
+    async def user_in_db(self, kamihi: Container, test_settings):
+        """Fixture that creates a user in the MongoDB database."""
+        from kamihi import BaseUser
+
+        class User(BaseUser):
+            name: str = StringField()
+
+        user = User(
+            telegram_id=test_settings.user_id,
+            name="John Doe",
+        ).save()
+
+        yield user
+
+        user.delete()
+
+    @pytest.mark.asyncio
+    async def test_action_parameter_user_custom(self, kamihi, user_in_db, add_permission_for_user, chat: Conversation):
+        """Test the action decorator without parentheses."""
+        add_permission_for_user(user_in_db, "start")
+
+        await chat.send_message("/start")
+        response = await chat.get_response()
+
+        assert response.text == f"Hello, {user_in_db.name}!"


### PR DESCRIPTION
Closes #46

This pull request introduces support for injecting a `user` parameter into bot action functions, enhances the test coverage for this new functionality, and includes minor adjustments to existing configurations and imports.

### New Feature: User Parameter Injection

* Updated `src/kamihi/bot/action.py` to allow the `user` parameter in action functions:
  - Modified `_validate_function` to recognize `user` as a valid parameter.
  - Added logic in the `__call__` method to inject a `user` object derived from the Telegram user ID.
  - Imported `get_user_from_telegram_id` for retrieving user objects.

### Functional Tests for User Parameter

* Added `tests/functional/bot/test_action_parameters.py` to test the `user` parameter injection:
  - Includes tests for both default and custom user classes.

### Unit Tests for User Parameter

* Enhanced `tests/unit/bot/test_action.py`:
  - Added a unit test for the `Action` class to verify the `user` parameter injection.
  - Imported `User` and updated imports to include `patch` for mocking. [[1]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610L12-R12) [[2]](diffhunk://#diff-dee5ef0740111d525d0f2153da88061b992d5694511f5e405e8fd0ee44289610R22)

### Minor Configuration Change

* Removed the `-n auto` option from `addopts` in `pyproject.toml` to simplify pytest configuration.