### PR TITLE
feat(bot): support sending files as action result

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,5 +12,8 @@
   ],
   labels: [
     "type:task"
+  ],
+  ignorePaths: [
+    "requirements.txt"
   ]
 }

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest tests/functional
+          uv run pytest tests/functional -x --retries 3
         env:
           KAMIHI_TESTING__BOT_TOKEN: ${{ secrets.TOKEN }}
           KAMIHI_TESTING__BOT_USERNAME: ${{ secrets.BOT_USERNAME }}

--- a/docs/guides/actions/send-files.md
+++ b/docs/guides/actions/send-files.md
@@ -1,0 +1,15 @@
+When you need to share a document, image, or other file, return a `Path` object pointing to the file.
+
+```python
+from kamihi import bot
+from pathlib import Path
+
+@bot.action
+async def send_report() -> Path:
+    # Generate or locate your file
+    report_path = Path("reports/monthly_summary.pdf")
+    return report_path
+```
+
+!!! warning
+    Use `Path` objects, not strings. Returning `"my_file.pdf"` sends the filename as a text message, not the actual file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
           - Configure the timezone: guides/config/configure-timezone.md
       - Actions:
           - Set commands: guides/actions/commands.md
+          - Send files: guides/actions/send-files.md
       - Users:
           - Extend the user model: guides/users/extend.md
       - Logging:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ unit = [
     "pytest>=8.3.5",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.1.1",
+    "pytest-retry>=1.7.0",
     "pytest-timeout>=2.4.0",
 ]
 

--- a/src/kamihi/base/config.py
+++ b/src/kamihi/base/config.py
@@ -145,7 +145,6 @@ class WebSettings(BaseModel):
     Defines the web settings schema.
 
     Attributes:
-        secret (str): The secret key for the web server.
         host (str): The host of the web interface.
         port (int): The port of the web interface.
 

--- a/src/kamihi/base/config.py
+++ b/src/kamihi/base/config.py
@@ -10,7 +10,6 @@ License:
 """
 
 import os
-import re
 from enum import StrEnum
 from pathlib import Path
 

--- a/src/kamihi/base/config.py
+++ b/src/kamihi/base/config.py
@@ -25,8 +25,6 @@ from pydantic_settings import (
 )
 from pytz.tzinfo import DstTzInfo
 
-_LEVEL_PATTERN = r"^(TRACE|DEBUG|INFO|SUCCESS|WARNING|ERROR|CRITICAL)$"
-
 
 class LogLevel(StrEnum):
     """
@@ -98,30 +96,6 @@ class LogSettings(BaseModel):
     notification_enable: bool = Field(default=False)
     notification_level: LogLevel = LogLevel.SUCCESS
     notification_urls: list[str] = Field(default_factory=list)
-
-    @field_validator("stdout_level", "stderr_level", "file_level", "notification_level")
-    @classmethod
-    def validate_log_level(cls, value: str) -> str:
-        """
-        Validate the log level value.
-
-        Args:
-            value (str): The log level value to validate.
-
-        Returns:
-            str: The validated log level value.
-
-        Raises:
-            ValueError: If the log level is invalid.
-
-        """
-        value = value.upper()
-
-        if not re.match(_LEVEL_PATTERN, value):
-            msg = f"Invalid log level: {value}"
-            raise ValueError(msg)
-
-        return value
 
 
 class ResponseSettings(BaseModel):

--- a/src/kamihi/bot/action.py
+++ b/src/kamihi/bot/action.py
@@ -17,7 +17,7 @@ from telegram import Update
 from telegram.constants import BotCommandLimit
 from telegram.ext import ApplicationHandlerStop, CallbackContext, CommandHandler
 
-from kamihi.tg import reply_text
+from kamihi.tg import reply
 from kamihi.tg.handlers import AuthHandler
 from kamihi.users import get_user_from_telegram_id
 
@@ -178,7 +178,7 @@ class Action:
 
         result = await self._func(*pos_args, **keyword_args)
         if result is not None:
-            await reply_text(update, context, result)
+            await reply(update, context, result)
         else:
             self._logger.debug("No result to send")
 

--- a/src/kamihi/tg/__init__.py
+++ b/src/kamihi/tg/__init__.py
@@ -9,6 +9,6 @@ License:
 """
 
 from .client import TelegramClient
-from .send import reply_text, send_text
+from .send import reply, send
 
-__all__ = ["TelegramClient", "reply_text", "send_text"]
+__all__ = ["TelegramClient", "reply", "send"]

--- a/src/kamihi/tg/default_handlers.py
+++ b/src/kamihi/tg/default_handlers.py
@@ -10,7 +10,7 @@ from loguru import logger
 from telegram import Update
 from telegram.ext import CallbackContext
 
-from .send import reply_text
+from .send import reply
 
 
 async def default(update: Update, context: CallbackContext) -> None:
@@ -27,7 +27,7 @@ async def default(update: Update, context: CallbackContext) -> None:
     )
 
     text = context.bot_data["responses"]["default_message"]
-    await reply_text(update, context, text)
+    await reply(update, context, text)
 
 
 async def error(update: object | None, context: CallbackContext) -> None:
@@ -43,4 +43,4 @@ async def error(update: object | None, context: CallbackContext) -> None:
 
     if isinstance(update, Update):
         text = context.bot_data["responses"]["error_message"]
-        await reply_text(update, context, text)
+        await reply(update, context, text)

--- a/src/kamihi/tg/send.py
+++ b/src/kamihi/tg/send.py
@@ -6,6 +6,8 @@ License:
 
 """
 
+from pathlib import Path
+
 from loguru import logger
 from telegram import Bot, Message, Update
 from telegram.error import TelegramError
@@ -44,20 +46,83 @@ async def send_text(
         return reply
 
 
-async def reply_text(update: Update, context: CallbackContext, text: str) -> None:
+async def send_file(bot: Bot, chat_id: int, file: Path, reply_to_message_id: int = None) -> Message | None:
+    """
+    Send a file to a chat.
+
+    This function sends a file to a specified chat using the provided bot instance.
+
+    Args:
+        bot (Bot): The Telegram Bot instance.
+        chat_id (int): The ID of the chat to send the file to.
+        file (Path): The file to send.
+        reply_to_message_id (int, optional): The ID of the message to reply to. Defaults to None.
+
+    Returns:
+        Message | None: The response from the Telegram API, or None if an error occurs.
+
+    """
+    lg = logger.bind(chat_id=chat_id, received_id=reply_to_message_id, path=file)
+
+    with lg.catch(exception=TelegramError, message="Failed to send file"):
+        reply = await bot.send_document(
+            chat_id=chat_id,
+            document=file,
+            filename=file.name,
+            reply_to_message_id=reply_to_message_id,
+        )
+        lg.bind(response_id=reply.message_id).debug("File sent")
+        return reply
+
+
+async def send(bot: Bot, chat_id: int, content: str | Path, reply_to_message_id: int = None) -> Message | None:
+    """
+    Send a message to a chat.
+
+    This function sends a message to a specified chat using the provided bot instance.
+    It can handle text and files.
+
+    Args:
+        bot (Bot): The Telegram Bot instance.
+        chat_id (int): The ID of the chat to send the message to.
+        content (str | Path): The content to send, which can be text or a file.
+        reply_to_message_id (int, optional): The ID of the message to reply to. Defaults to None.
+
+    Returns:
+        Message | None: The response from the Telegram API, or None if an error occurs.
+
+    """
+    match content:
+        case str():
+            return await send_text(bot, chat_id, content, reply_to_message_id)
+        case Path():
+            return await send_file(bot, chat_id, content, reply_to_message_id)
+        case _:
+            logger.error("Unsupported content type: {}", type(content))
+            return None
+
+
+async def reply(
+    update: Update,
+    context: CallbackContext,
+    content: str | Path,
+) -> Message | None:
     """
     Reply to a message update.
 
-    Convenience method to send a text message in response to an update.
+    This function replies to a message update with either text or a file.
 
     Args:
         update: the update object
         context: the context object
-        text: the text to send
+        content: the content to send, which can be text or a file
+
+    Returns:
+        Message | None: The response from the Telegram API, or None if an error occurs.
 
     """
     bot = context.bot
     chat_id = update.effective_message.chat_id
     message_id = update.effective_message.message_id
 
-    await send_text(bot, chat_id, text, message_id)
+    return await send(bot, chat_id, content, reply_to_message_id=message_id)

--- a/src/kamihi/tg/send.py
+++ b/src/kamihi/tg/send.py
@@ -38,13 +38,13 @@ async def send_text(
     lg = logger.bind(chat_id=chat_id, received_id=reply_to_message_id, response_text=text)
 
     with lg.catch(exception=TelegramError, message="Failed to send message"):
-        reply = await bot.send_message(
+        message_reply = await bot.send_message(
             chat_id,
             md(text),
             reply_to_message_id=reply_to_message_id,
         )
-        lg.bind(response_id=reply.message_id).debug("Reply sent" if reply_to_message_id else "Message sent")
-        return reply
+        lg.bind(response_id=message_reply.message_id).debug("Reply sent" if reply_to_message_id else "Message sent")
+        return message_reply
 
 
 async def send_file(bot: Bot, chat_id: int, file: Path, reply_to_message_id: int = None) -> Message | None:
@@ -93,14 +93,14 @@ async def send_file(bot: Bot, chat_id: int, file: Path, reply_to_message_id: int
         lg.warning("File is empty")
 
     with lg.catch(exception=TelegramError, message="Failed to send file"):
-        reply = await bot.send_document(
+        message_reply = await bot.send_document(
             chat_id=chat_id,
             document=file,
             filename=file.name,
             reply_to_message_id=reply_to_message_id,
         )
-        lg.bind(response_id=reply.message_id).debug("File sent")
-        return reply
+        lg.bind(response_id=message_reply.message_id).debug("File sent")
+        return message_reply
 
 
 async def send(bot: Bot, chat_id: int, content: str | Path, reply_to_message_id: int = None) -> Message | None:

--- a/tests/functional/bot/test_action_returns.py
+++ b/tests/functional/bot/test_action_returns.py
@@ -1,0 +1,74 @@
+"""
+Functional tests for action returns.
+
+License:
+    MIT
+"""
+
+from textwrap import dedent
+
+import pytest
+from telethon import TelegramClient
+from telethon.tl.custom import Conversation, Message
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("kamihi")
+@pytest.mark.parametrize(
+    "actions_folder",
+    [
+        {
+            "actions/start/__init__.py": "".encode(),
+            "actions/start/start.py": dedent("""\
+                from kamihi import bot
+                             
+                @bot.action
+                async def start():
+                    return "Hello!"
+            """).encode(),
+        }
+    ],
+)
+async def test_action_returns_string(user_in_db, add_permission_for_user, chat: Conversation, actions_folder):
+    """Test the action decorator without parentheses."""
+    add_permission_for_user(user_in_db, "start")
+
+    await chat.send_message("/start")
+    response: Message = await chat.get_response()
+
+    assert response.text == "Hello!"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("kamihi")
+@pytest.mark.parametrize(
+    "actions_folder",
+    [
+        {
+            "actions/start/__init__.py": "".encode(),
+            "actions/start/start.py": dedent("""\
+                from kamihi import bot
+                from pathlib import Path
+                             
+                @bot.action
+                async def start():
+                    return Path("actions/start/file.txt")
+            """).encode(),
+            "actions/start/file.txt": "This is a file.".encode(),
+        }
+    ],
+)
+async def test_action_returns_file(user_in_db, add_permission_for_user, chat: Conversation, tg_client: TelegramClient, actions_folder, tmp_path):
+    """Test the action decorator without parentheses."""
+    add_permission_for_user(user_in_db, "start")
+
+    await chat.send_message("/start")
+    response: Message = await chat.get_response()
+
+    assert response.__getattribute__("file") is not None
+    assert response.file.name == "file.txt"
+
+    await tg_client.download_media(response, str(tmp_path))
+    dpath = tmp_path / "file.txt"
+    assert dpath.exists()
+    assert dpath.read_text() == "This is a file."

--- a/tests/functional/bot/test_action_returns.py
+++ b/tests/functional/bot/test_action_returns.py
@@ -58,7 +58,9 @@ async def test_action_returns_string(user_in_db, add_permission_for_user, chat: 
         }
     ],
 )
-async def test_action_returns_file(user_in_db, add_permission_for_user, chat: Conversation, tg_client: TelegramClient, actions_folder, tmp_path):
+async def test_action_returns_file(
+    user_in_db, add_permission_for_user, chat: Conversation, tg_client: TelegramClient, actions_folder, tmp_path
+):
     """Test the action decorator without parentheses."""
     add_permission_for_user(user_in_db, "start")
 

--- a/tests/unit/base/test_config.py
+++ b/tests/unit/base/test_config.py
@@ -347,7 +347,7 @@ timezone: Europe/London
     try:
         # Load settings from YAML file
         settings = KamihiSettings.from_yaml(yaml_path)
-        
+
         # Verify all settings were loaded correctly
         assert settings.log.stdout_level == "WARNING"
         assert settings.log.stderr_enable is True
@@ -376,11 +376,11 @@ timezone: Asia/Tokyo
     try:
         # Load settings from YAML file
         settings = KamihiSettings.from_yaml(yaml_path)
-        
+
         # Verify specified settings were loaded
         assert settings.log.stdout_level == "ERROR"
         assert settings.timezone == "Asia/Tokyo"
-        
+
         # Verify default values are preserved for unspecified settings
         assert settings.log.stderr_enable is False  # Default value
         assert settings.db.host == "mongodb://localhost:27017"  # Default value
@@ -395,13 +395,13 @@ def test_from_yaml_with_nonexistent_file():
     """Test loading settings from a non-existent YAML file returns default settings."""
     # Use a path that doesn't exist
     nonexistent_path = Path("/tmp/nonexistent_config.yaml")
-    
+
     # Ensure the file doesn't exist
     assert not nonexistent_path.exists()
-    
+
     # Load settings from non-existent file
     settings = KamihiSettings.from_yaml(nonexistent_path)
-    
+
     # Verify default settings are returned
     assert settings.log.stdout_level == "INFO"  # Default value
     assert settings.log.stderr_enable is False  # Default value
@@ -420,7 +420,7 @@ def test_from_yaml_with_empty_file():
     try:
         # Load settings from empty file
         settings = KamihiSettings.from_yaml(yaml_path)
-        
+
         # Verify default settings are returned
         assert settings.log.stdout_level == "INFO"  # Default value
         assert settings.log.stderr_enable is False  # Default value
@@ -443,7 +443,7 @@ def test_from_yaml_with_null_content():
     try:
         # Load settings from file with null content
         settings = KamihiSettings.from_yaml(yaml_path)
-        
+
         # Verify default settings are returned
         assert settings.log.stdout_level == "INFO"  # Default value
         assert settings.log.stderr_enable is False  # Default value
@@ -503,13 +503,13 @@ def test_from_yaml_with_directory_path():
     # Create a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
         dir_path = Path(temp_dir)
-        
+
         # Ensure it's a directory, not a file
         assert dir_path.is_dir()
-        
+
         # Load settings from directory path
         settings = KamihiSettings.from_yaml(dir_path)
-        
+
         # Verify default settings are returned
         assert settings.log.stdout_level == "INFO"  # Default value
         assert settings.log.stderr_enable is False  # Default value
@@ -560,7 +560,7 @@ autoreload_templates: false
     try:
         # Load settings from YAML file
         settings = KamihiSettings.from_yaml(yaml_path)
-        
+
         # Verify all log settings
         assert settings.log.stdout_enable is True
         assert settings.log.stdout_level == "DEBUG"
@@ -578,22 +578,22 @@ autoreload_templates: false
         assert settings.log.notification_level == "SUCCESS"
         assert settings.log.notification_urls == [
             "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-            "https://discord.com/api/webhooks/123456789/abcdefgh"
+            "https://discord.com/api/webhooks/123456789/abcdefgh",
         ]
-        
+
         # Verify database settings
         assert settings.db.host == "mongodb+srv://user:password@cluster0.mongodb.net"
         assert settings.db.name == "production_db"
-        
+
         # Verify response settings
         assert settings.responses.default_enabled is False
         assert settings.responses.default_message == "Custom default message"
         assert settings.responses.error_message == "Custom error message"
-        
+
         # Verify web settings
         assert settings.web.host == "0.0.0.0"
         assert settings.web.port == 8080
-        
+
         # Verify general settings
         assert settings.timezone == "America/New_York"
         assert settings.testing is False
@@ -616,10 +616,10 @@ timezone: Europe/Paris
     try:
         # Load settings from YAML file
         settings = KamihiSettings.from_yaml(yaml_path)
-        
+
         # Verify specified setting
         assert settings.timezone == "Europe/Paris"
-        
+
         # Verify all other sections preserve defaults
         assert settings.log.stdout_level == "INFO"  # Default LogSettings
         assert settings.log.stderr_enable is False  # Default LogSettings

--- a/tests/unit/tg/test_default_handlers.py
+++ b/tests/unit/tg/test_default_handlers.py
@@ -11,6 +11,7 @@ License:
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from logot import Logot, logged
 from telegram import Update
 from telegram.ext import CallbackContext
 
@@ -37,122 +38,70 @@ def mock_context():
 
 @pytest.mark.asyncio
 async def test_default_handler(mock_update, mock_context):
-    """
-    Test that the default handler calls reply_text with the correct message.
-
-    Validates supports acciones-comandos-formato indirectly by ensuring
-    users receive appropriate responses when commands aren't recognized.
-    """
-    # Patch reply_text to verify it's called with the right parameters
-    with patch("kamihi.tg.default_handlers.reply_text", new=AsyncMock()) as mock_reply:
+    """Test that the default handler calls reply with the correct message."""
+    # Patch reply to verify it's called with the right parameters
+    with patch("kamihi.tg.default_handlers.reply", new=AsyncMock()) as mock_reply:
         # Call the default handler
         await default(mock_update, mock_context)
 
-        # Verify reply_text is called with the correct text from bot_data
+        # Verify reply is called with the correct text from bot_data
         mock_reply.assert_called_once_with(
             mock_update, mock_context, mock_context.bot_data["responses"]["default_message"]
         )
 
 
 @pytest.mark.asyncio
-async def test_default_handler_logging(mock_update, mock_context):
-    """
-    Test that the default handler logs the message correctly.
+async def test_default_handler_logging(logot: Logot, mock_update, mock_context):
+    """Test that the default handler logs the message correctly."""
+    # Patch reply to avoid actually calling it
+    with patch("kamihi.tg.default_handlers.reply", new=AsyncMock()) as mock_reply:
+        # Call the default handler
+        await default(mock_update, mock_context)
 
-    Validates system diagnostic functionality that supports proper
-    operation of acciones-comandos-reconocimiento.
-    """
-    # Patch reply_text to avoid actually calling it
-    with patch("kamihi.tg.default_handlers.reply_text", new=AsyncMock()):
-        # Patch logger to verify logging behavior
-        with patch("kamihi.tg.default_handlers.logger") as mock_logger:
-            # Set up bind return value to enable method chaining
-            bind_mock = Mock()
-            mock_logger.bind.return_value = bind_mock
+        # Verify reply is called
+        logot.assert_logged(logged.debug("Received message but no handler matched, so sending default response"))
 
-            # Call the default handler
-            await default(mock_update, mock_context)
-
-            # Verify logger.bind is called with chat_id and message_id
-            mock_logger.bind.assert_called_once_with(
-                chat_id=mock_update.effective_message.chat_id, message_id=mock_update.effective_message.message_id
-            )
-
-            # Verify debug log is called with the correct message
-            bind_mock.debug.assert_called_once_with(
-                "Received message but no handler matched, so sending default response"
-            )
+        # Verify reply is called with the correct text
+        mock_reply.assert_called_once_with(
+            mock_update, mock_context, mock_context.bot_data["responses"]["default_message"]
+        )
 
 
 @pytest.mark.asyncio
-async def test_error_handler_with_update(mock_update, mock_context):
-    """
-    Test error handler behavior when an update is available.
-
-    Validates supports acciones-comandos-formato by ensuring users
-    receive appropriate error messages.
-    """
+async def test_error_handler_update(logot: Logot, mock_update, mock_context):
+    """Test error handler behavior when an update is available."""
     # Set up an error in the context
     test_error = Exception("Test error")
     mock_context.error = test_error
 
-    # Patch reply_text to verify it gets called
-    with patch("kamihi.tg.default_handlers.reply_text", new=AsyncMock()) as mock_reply:
+    # Patch reply to verify it gets called
+    with patch("kamihi.tg.default_handlers.reply", new=AsyncMock()) as mock_reply:
         # Call the error handler with a valid update
         await error(mock_update, mock_context)
 
-        # Verify reply_text is called with the error text
+        # Verify that the logger is called with the error
+        logot.assert_logged(logged.error("An error occurred"))
+
+        # Verify reply is called with the error text
         mock_reply.assert_called_once_with(
             mock_update, mock_context, mock_context.bot_data["responses"]["error_message"]
         )
 
 
 @pytest.mark.asyncio
-async def test_error_handler_no_update():
-    """
-    Test error handler behavior when no update is available.
-
-    Validates system robustness that supports acciones-comandos-concurrencia
-    by ensuring errors don't crash the system.
-    """
+async def test_error_handler_no_update(logot: Logot):
+    """Test error handler behavior when no update is available."""
     # Create a context with an error, but no update
     mock_context = Mock(spec=CallbackContext)
     mock_context.error = Exception("Test error")
-    mock_context.bot_data = {"responses": {"error_text": "Error occurred"}}
 
-    # Patch reply_text to verify it's NOT called when there's no update
-    with patch("kamihi.tg.default_handlers.reply_text", new=AsyncMock()) as mock_reply:
+    # Patch reply to verify it's NOT called when there's no update
+    with patch("kamihi.tg.default_handlers.reply", new=AsyncMock()) as mock_reply:
         # Call the error handler with no update (None)
         await error(None, mock_context)
 
-        # Verify reply_text is NOT called (since update is None)
+        # Verify that the logger is called with the error
+        logot.assert_logged(logged.error("An error occurred"))
+
+        # Verify reply is NOT called (since update is None)
         mock_reply.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_error_handler_logging():
-    """
-    Test that the error handler properly logs the exception.
-
-    Validates system diagnostic functionality that supports proper
-    operation of all error handling.
-    """
-    # Create context with a test error
-    mock_context = Mock(spec=CallbackContext)
-    test_error = Exception("Test error")
-    mock_context.error = test_error
-
-    # Patch logger to verify logging behavior
-    with patch("kamihi.tg.default_handlers.logger") as mock_logger:
-        # Set up opt return value
-        opt_mock = Mock()
-        mock_logger.opt.return_value = opt_mock
-
-        # Call the error handler
-        await error(None, mock_context)
-
-        # Verify logger.opt is called with the exception
-        mock_logger.opt.assert_called_once_with(exception=test_error)
-
-        # Verify error log is called with the correct message
-        opt_mock.error.assert_called_once_with("An error occurred")

--- a/tests/unit/tg/test_send.py
+++ b/tests/unit/tg/test_send.py
@@ -238,7 +238,7 @@ async def test_send_file_with_invalid_path(logot: Logot, mock_ptb_bot):
     result = await send_file(mock_ptb_bot, chat_id, invalid_path)
 
     # Verify that the logger was called with an error
-    logot.assert_logged(logged.error(f"File does not exist"))
+    logot.assert_logged(logged.error("File does not exist"))
     # Verify function returns None
     assert result is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,7 @@ unit = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-retry" },
     { name = "pytest-timeout" },
 ]
 
@@ -626,6 +627,7 @@ unit = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-retry", specifier = ">=1.7.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
 ]
 
@@ -1328,6 +1330,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/88/2f61cdaa81552795ff43420b5869af17585bc55432b44ef1aa882251890e/pytest_playwright_asyncio-0.7.0.tar.gz", hash = "sha256:bf811e2164a74cc743394a327b68ee71f3f924b1ea3e29220499c8d7b03f6af1", size = 16706, upload-time = "2025-01-31T11:06:06.43Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/22/9fb8eb62fbc0cfb7c608c4f04b0ee5a4188b05cdead119adc031c0d96593/pytest_playwright_asyncio-0.7.0-py3-none-any.whl", hash = "sha256:f0a41b7f2967f7f514bd499026555eca0b3be6423f78831b86587def8fc50572", size = 16835, upload-time = "2025-01-31T11:06:09.811Z" },
+]
+
+[[package]]
+name = "pytest-retry"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/5b/607b017994cca28de3a1ad22a3eee8418e5d428dcd8ec25b26b18e995a73/pytest_retry-1.7.0.tar.gz", hash = "sha256:f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f", size = 19977, upload-time = "2025-01-19T01:56:13.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/ff/3266c8a73b9b93c4b14160a7e2b31d1e1088e28ed29f4c2d93ae34093bfd/pytest_retry-1.7.0-py3-none-any.whl", hash = "sha256:a2dac85b79a4e2375943f1429479c65beb6c69553e7dae6b8332be47a60954f4", size = 13775, upload-time = "2025-01-19T01:56:11.199Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #77.

This pull request introduces several significant updates to the `kamihi` project, focusing on enhancing file handling capabilities, refactoring existing messaging functions, and updating tests to align with the new functionality. The most important changes include adding support for sending files via bot actions, replacing the `reply_text` function with a more versatile `reply` function, and updating documentation and tests accordingly.

### File Handling Enhancements:
* [`src/kamihi/tg/send.py`](diffhunk://#diff-e6de53afca629fa0ec2da649714a72757a1830c860611ece7bc6758f6b4c0c3eR9-R13): Introduced the `send_file` function to validate and send files, and updated the `send` and `reply` functions to handle both text and file content. Added validation for file existence, readability, and size limits. [[1]](diffhunk://#diff-e6de53afca629fa0ec2da649714a72757a1830c860611ece7bc6758f6b4c0c3eR9-R13) [[2]](diffhunk://#diff-e6de53afca629fa0ec2da649714a72757a1830c860611ece7bc6758f6b4c0c3eL47-R156)
* [`docs/guides/actions/send-files.md`](diffhunk://#diff-3abfabaab45de2c58a8ac3445586eb53bf5a5e172c83f9658a6e8d0ba8e045beR1-R15): Added documentation for sending files using the `Path` object in bot actions, with warnings about proper usage.

### Messaging Function Refactor:
* [`src/kamihi/tg/__init__.py`](diffhunk://#diff-7365ec03c03134be1dce68ae1fc2a2049164a83bd12b8f57de006a6da103a0caL12-R14): Replaced `reply_text` with `reply` in the module exports to unify text and file handling under one function.
* [`src/kamihi/bot/action.py`](diffhunk://#diff-74fe118ac1ef85b97b5914687ec7bd2d05566ae11fa8f64823c5164ef633f0edL20-R20): Updated all instances of `reply_text` to use the new `reply` function for sending messages. [[1]](diffhunk://#diff-74fe118ac1ef85b97b5914687ec7bd2d05566ae11fa8f64823c5164ef633f0edL20-R20) [[2]](diffhunk://#diff-74fe118ac1ef85b97b5914687ec7bd2d05566ae11fa8f64823c5164ef633f0edL181-R181)
* [`src/kamihi/tg/default_handlers.py`](diffhunk://#diff-91df4e6893bafa425aa74410200169a3bd18b981c4fff4c35688ca2ee1ebe9f4L13-R13): Refactored default and error handlers to use the new `reply` function, ensuring compatibility with both text and file responses. [[1]](diffhunk://#diff-91df4e6893bafa425aa74410200169a3bd18b981c4fff4c35688ca2ee1ebe9f4L13-R13) [[2]](diffhunk://#diff-91df4e6893bafa425aa74410200169a3bd18b981c4fff4c35688ca2ee1ebe9f4L30-R30) [[3]](diffhunk://#diff-91df4e6893bafa425aa74410200169a3bd18b981c4fff4c35688ca2ee1ebe9f4L46-R46)

### Testing Updates:
* [`tests/functional/bot/test_action_returns.py`](diffhunk://#diff-100d8a5a8c9edbf58c9a5500b40ab0952dfa8038e382ad67b34d9ab5a2190340R1-R74): Added functional tests to validate bot actions returning both strings and files, ensuring proper file sending and downloading.
* [`tests/unit/tg/test_default_handlers.py`](diffhunk://#diff-256f048494b3ab49c4360b213d45ccdf6b7eec50aef5eb55a5afeb2b1c0c008bR14): Updated unit tests for default and error handlers to use the `reply` function, and introduced `Logot` for enhanced logging verification. [[1]](diffhunk://#diff-256f048494b3ab49c4360b213d45ccdf6b7eec50aef5eb55a5afeb2b1c0c008bR14) [[2]](diffhunk://#diff-256f048494b3ab49c4360b213d45ccdf6b7eec50aef5eb55a5afeb2b1c0c008bL40-R107)

### Documentation and Configuration:
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R29): Added a new navigation entry for the "Send files" guide in the documentation.
* [`src/kamihi/base/config.py`](diffhunk://#diff-54aa5496517b316a94c3e2d8558aa326842e826ca47f42634c2af701e2a743ceL148): Removed an unused attribute (`secret`) from the `WebSettings` schema.